### PR TITLE
Fix cterm background to match terminal

### DIFF
--- a/colors/snazzy.vim
+++ b/colors/snazzy.vim
@@ -43,7 +43,7 @@ let  ui_12    =  '#192224'
 "hi CTagsMember -- no settings --
 "hi CTagsGlobalConstant -- no settings --
 "hi Ignore -- no settings --
-:exe  'highlight  Normal          guifg='.ui_1.'      guibg='.ui_11.'   guisp='.ui_11.'   gui=NONE       ctermfg=189   ctermbg=237   cterm=NONE'
+:exe  'highlight  Normal          guifg='.ui_1.'      guibg='.ui_11.'   guisp='.ui_11.'   gui=NONE       ctermfg=White   ctermbg=Black   cterm=NONE'
 "hi CTagsImport -- no settings --
 "hi CTagsGlobalVariable -- no settings --
 "hi EnumerationValue -- no settings --


### PR DESCRIPTION
# The issue
When I downloaded the theme the background color was set to a specific black instead of matching my Hyper terminal background. 

By replacing ctermfg=189   ctermbg=237 with ctermfg=White   ctermbg=Black
the background colors will match the terminals white and black.

# Before change
<img width="1274" alt="screen shot 2018-04-18 at 16 04 25" src="https://user-images.githubusercontent.com/15928717/38937046-8cfa9174-4322-11e8-9ebe-0707abaa5a20.png">

# After change
<img width="1273" alt="screen shot 2018-04-18 at 16 07 32" src="https://user-images.githubusercontent.com/15928717/38937076-a10fe48e-4322-11e8-9ff2-43192023b558.png">

